### PR TITLE
Added an extra to remove account information

### DIFF
--- a/Unofficial 4.2.4 Patch/Extras/Client Windows/Removed Account name and email/Install/steam/cached/AccountPage.res
+++ b/Unofficial 4.2.4 Patch/Extras/Client Windows/Removed Account name and email/Install/steam/cached/AccountPage.res
@@ -1,0 +1,39 @@
+"Steam/cached/AccountPage.res"
+{
+	styles
+	{
+		Divider
+		{
+			bgcolor=white12
+		}
+	}
+
+	layout
+	{
+		region { name=box margin-left=16 margin-right=16 }
+
+		//Avatar
+		place { region=box control="SecurityIcon" dir=right y=12 spacing=6 }
+
+		///Information
+		place { region=box control="LogOutLabel,AccountInfo" x=68 y=7 spacing=6 }
+		place { region=box control="ContactEmailLabel,EmailInfo" x=68 y=24 spacing=6 }
+		place { region=box control="SecurityStatusLabel,SecurityStatusState" x=68 y=41 spacing=6 }
+		place { region=box control="Label2,VacInfoLink" x=68 y=58 spacing=6 }
+
+		place { region=box control="NoPersonalInfoCheck" y=86 spacing=8 dir=down }
+
+		//Security Information
+		place { region=box start=NoPersonalInfoCheck control="ChangeUserButton,ManageSecurityButton,ChangePasswordButton,ChangeContactEmailButton,ValidateContactEmailButton,MachineLockAccountButton" margin-top=16 width=337 height=28 dir=down spacing=6 }
+
+		//Beta Participation
+		place { region=box control="Divider1" y=340 }
+		place { region=box start=Divider1 control="BetaParticipationLabel" y=27 dir=down }
+		place { region=box start=BetaParticipationLabel control="Divider2" y=32 height=1 dir=down }
+		place { region=box start=BetaParticipationLabel control="ChangeBetaButton" x=6 y=-3 width=84 height=28 spacing=6 }
+		place { region=box start=ChangeBetaButton control="CurrentBetaLabel" x=6 y=3 height=24 }
+
+		//Hidden
+		place { control="AccountInfo,EmailInfo,ReportBugLink,Label1,AccountLink" width=1 height=1 align=right }
+	}
+}

--- a/Unofficial 4.2.4 Patch/Extras/Client Windows/Removed Account name and email/Note.txt
+++ b/Unofficial 4.2.4 Patch/Extras/Client Windows/Removed Account name and email/Note.txt
@@ -1,0 +1,1 @@
+This will remove the Account Name and Contact Email under Settings > Account. It can be useful for streamers looking to hide their account information.

--- a/Unofficial 4.2.4 Patch/Extras/Client Windows/Removed Account name and email/Uninstall/steam/cached/AccountPage.res
+++ b/Unofficial 4.2.4 Patch/Extras/Client Windows/Removed Account name and email/Uninstall/steam/cached/AccountPage.res
@@ -1,0 +1,39 @@
+"Steam/cached/AccountPage.res"
+{
+	styles
+	{
+		Divider
+		{
+			bgcolor=white12
+		}
+	}
+
+	layout
+	{
+		region { name=box margin-left=16 margin-right=16 }
+
+		//Avatar
+		place { region=box control="SecurityIcon" dir=right y=12 spacing=6 }
+
+		///Information
+		place { region=box control="LogOutLabel,AccountInfo" x=68 y=7 spacing=6 }
+		place { region=box control="ContactEmailLabel,EmailInfo" x=68 y=24 spacing=6 }
+		place { region=box control="SecurityStatusLabel,SecurityStatusState" x=68 y=41 spacing=6 }
+		place { region=box control="Label2,VacInfoLink" x=68 y=58 spacing=6 }
+
+		place { region=box control="NoPersonalInfoCheck" y=86 spacing=8 dir=down }
+
+		//Security Information
+		place { region=box start=NoPersonalInfoCheck control="ChangeUserButton,ManageSecurityButton,ChangePasswordButton,ChangeContactEmailButton,ValidateContactEmailButton,MachineLockAccountButton" margin-top=16 width=337 height=28 dir=down spacing=6 }
+
+		//Beta Participation
+		place { region=box control="Divider1" y=340 }
+		place { region=box start=Divider1 control="BetaParticipationLabel" y=27 dir=down }
+		place { region=box start=BetaParticipationLabel control="Divider2" y=32 height=1 dir=down }
+		place { region=box start=BetaParticipationLabel control="ChangeBetaButton" x=6 y=-3 width=84 height=28 spacing=6 }
+		place { region=box start=ChangeBetaButton control="CurrentBetaLabel" x=6 y=3 height=24 }
+
+		//Hidden
+		place { control="ReportBugLink,Label1,AccountLink" width=1 height=1 align=right }
+	}
+}


### PR DESCRIPTION
I often show my desktop while streaming on Twitch. The Metro skin is great because it replaces the account name on the Steam main window by an icon. However, this information can also be found along with the account email when opening Steam settings (the account tab is the first one in the list), which is why I decided to offer a way to hide them.

The email can also be seen in the Email reminder bar at the top of the Steam main window but it's only displayed every couple of weeks so I think it's not necessary to hide it there as well.