### PR TITLE
Accent scrollbar bugfix

### DIFF
--- a/Unofficial 4.2.4 Patch/Extras/Client Windows/Accent Scrollbars/Install/colors.styles
+++ b/Unofficial 4.2.4 Patch/Extras/Client Windows/Accent Scrollbars/Install/colors.styles
@@ -83,17 +83,17 @@
 
 ///////////////////////////////////////
 //======Nickname/Balance Button======//
-		ingameNick=white
-		onlineNick=white
-		offlineNick=white
+		ingameNick=Friends_InGame
+		onlineNick=Friends_Online
+		offlineNick=Friends_Offline
 
-		bgIngameNick=Friends_InGame
-		bgOnlineNick=Friends_Online
+		bgIngameNick=none
+		bgOnlineNick=none
 		bgOfflineNick=none
 
-		bgIngameNearAvatar=none
-		bgOnlineNearAvatar=none
-		bgOfflineNearAvatar=none
+		bgIngameNearAvatar=Friends_InGame
+		bgOnlineNearAvatar=Friends_Online
+		bgOfflineNearAvatar=Friends_Offline
 
 		textCash=white
 		bgTextCash=none

--- a/Unofficial 4.2.4 Patch/Extras/Client Windows/Accent Scrollbars/Uninstall/colors.styles
+++ b/Unofficial 4.2.4 Patch/Extras/Client Windows/Accent Scrollbars/Uninstall/colors.styles
@@ -83,17 +83,17 @@
 
 ///////////////////////////////////////
 //======Nickname/Balance Button======//
-		ingameNick=white
-		onlineNick=white
-		offlineNick=white
+		ingameNick=Friends_InGame
+		onlineNick=Friends_Online
+		offlineNick=Friends_Offline
 
-		bgIngameNick=Friends_InGame
-		bgOnlineNick=Friends_Online
+		bgIngameNick=none
+		bgOnlineNick=none
 		bgOfflineNick=none
 
-		bgIngameNearAvatar=none
-		bgOnlineNearAvatar=none
-		bgOfflineNearAvatar=none
+		bgIngameNearAvatar=Friends_InGame
+		bgOnlineNearAvatar=Friends_Online
+		bgOfflineNearAvatar=Friends_Offline
 
 		textCash=white
 		bgTextCash=none

--- a/Unofficial 4.2.4 Patch/Extras/Client Windows/Blue Scrollbars/Install/colors.styles
+++ b/Unofficial 4.2.4 Patch/Extras/Client Windows/Blue Scrollbars/Install/colors.styles
@@ -83,17 +83,17 @@
 
 ///////////////////////////////////////
 //======Nickname/Balance Button======//
-		ingameNick=white
-		onlineNick=white
-		offlineNick=white
+		ingameNick=Friends_InGame
+		onlineNick=Friends_Online
+		offlineNick=Friends_Offline
 
-		bgIngameNick=Friends_InGame
-		bgOnlineNick=Friends_Online
+		bgIngameNick=none
+		bgOnlineNick=none
 		bgOfflineNick=none
 
-		bgIngameNearAvatar=none
-		bgOnlineNearAvatar=none
-		bgOfflineNearAvatar=none
+		bgIngameNearAvatar=Friends_InGame
+		bgOnlineNearAvatar=Friends_Online
+		bgOfflineNearAvatar=Friends_Offline
 
 		textCash=white
 		bgTextCash=none

--- a/Unofficial 4.2.4 Patch/Extras/Client Windows/Blue Scrollbars/Uninstall/colors.styles
+++ b/Unofficial 4.2.4 Patch/Extras/Client Windows/Blue Scrollbars/Uninstall/colors.styles
@@ -83,17 +83,17 @@
 
 ///////////////////////////////////////
 //======Nickname/Balance Button======//
-		ingameNick=white
-		onlineNick=white
-		offlineNick=white
+		ingameNick=Friends_InGame
+		onlineNick=Friends_Online
+		offlineNick=Friends_Offline
 
-		bgIngameNick=Friends_InGame
-		bgOnlineNick=Friends_Online
+		bgIngameNick=none
+		bgOnlineNick=none
 		bgOfflineNick=none
 
-		bgIngameNearAvatar=none
-		bgOnlineNearAvatar=none
-		bgOfflineNearAvatar=none
+		bgIngameNearAvatar=Friends_InGame
+		bgOnlineNearAvatar=Friends_Online
+		bgOfflineNearAvatar=Friends_Offline
 
 		textCash=white
 		bgTextCash=none


### PR DESCRIPTION
colors.styles in accent scrollbar install/uninstall folders were not updated for the new nickname button, breaking the background. This is to patch that by updating the variables.