### PR TITLE
fix layout missing Steam Play items for Linux clients

### DIFF
--- a/Unofficial 4.3.1 Patch/Main Files [Install First]/resource/layout/gameproperties_general.layout
+++ b/Unofficial 4.3.1 Patch/Main Files [Install First]/resource/layout/gameproperties_general.layout
@@ -98,6 +98,20 @@
 			"ControlName"		"Label"
 			"labelText"		"#Steam_Game_Family_Sharing_Unsupported"
 		}
+		"Divider3" [$LINUX]
+		{
+			"ControlName"		"Divider"
+		}
+		"SteamPlayOverrideCheck" [$LINUX]
+		{
+			"ControlName"		"CheckButton"
+			"labelText"		"#Steam_GameProperties_SteamPlaySettings_Override"
+			"Default"		"0"
+		}
+		"SteamPlayOverrideCombo" [$LINUX]
+		{
+			"ControlName"		"ComboBox"
+		}
 	}
 	colors
 	{
@@ -129,7 +143,8 @@
 		place {control=Divider2 start=CreateDesktopShortcutButton dir=down margin-top=20 region=main width=max }
 		place {control=SteamInputPerGameLabel start=Divider2 dir=down margin-top=20 }
 		place {control=SteamInputPerGameCombo start=SteamInputPerGameLabel y=6 dir=down width=450 }
-
+		place [$LINUX] {control=Divider3 start=SteamInputPerGameCombo dir=down margin-top=20 region=main width=max }
+		place [$LINUX] {controls=SteamPlayOverrideCheck,SteamPlayOverrideCombo start=Divider3 dir=down margin-top=20 spacing=10 width=max region=main }
 		place {controls=FamilySharingUnsupportedLabel margin-top=472 margin-left=16 }
 	}
 }


### PR DESCRIPTION
There's also an issue for the "gamespage_details_compat_subheader.layout" file not showing body text correctly (text is cut off) but I am not sure how to address it