### PR TITLE
Change "Update news" label to "View News" label in Steam Menu

### DIFF
--- a/Unofficial 4.3.1 Patch/Main Files [Install First]/resource/menus/steam.menu
+++ b/Unofficial 4.3.1 Patch/Main Files [Install First]/resource/menus/steam.menu
@@ -14,7 +14,7 @@
 		ViewPlayerList		{	text="#steam_menu_view_players"			shellcmd="steam://friends/players" }
 		Servers			{	text="#steam_menu_servers"			shellcmd="steam://open/servers" }
 		Screenshots		{	text="#steam_screenshots"			command="Screenshots" }
-		NewForYou		{	text="#SteamUI_GameProperties_UpdateNews"	shellcmd="steam://open/newforyou" }
+		NewForYou		{	text="#Steam_GamesDialog_RightClick_UpdateNews"	shellcmd="steam://open/newforyou" }
 		Divider {}
 		ActivateRetail		{	text="#Steam_RegisterProductCode"		command="ActivateRetail" }
 		RedeemWalletVoucher	{	text="#Steam_RedeemWalletVoucher"		shellcmd="steam://url/RedeemWalletVoucher" }


### PR DESCRIPTION
Purely cosmetic, but fixes the very out of place looking label. "View News" more accurately describes its function, but a cleaner label option would be "Steam_UpdateNewsButton", which is "View Updates". Either one of these is infinitely better, however I believe News is the better option of the two.