### PR TITLE
Fixed left padding issue for New Library sidebar

### DIFF
--- a/Unofficial 4.x Patch/Main Files [Install First]/resource/layout/uinavigatorpanel.layout
+++ b/Unofficial 4.x Patch/Main Files [Install First]/resource/layout/uinavigatorpanel.layout
@@ -514,7 +514,7 @@ layout [$WINDOWS]
 	place { control=ScreenshotsPage 	y=39 width=max height=max margin-top=1 start=subnavgroup_library dir=down }
 
 	place { control=ConsolePage 		y=39 width=max height=max margin-bottom=1 start=subnavgroup_library dir=down }
-  place { control=NewLibraryPage	width=max height=max margin-top=40 margin-left=-6 margin-right=0 margin-bottom=1 start=subnavgroup_library dir=down }
+  place { control=NewLibraryPage	width=max height=max margin-top=40 margin-left=0 margin-right=0 margin-bottom=1 start=subnavgroup_library dir=down }
 	place { control=MediaPage 			y=39 width=max height=max margin-bottom=1 start=subnavgroup_library dir=down }
 	place { control=ToolsPage 			y=39 width=max height=max margin-bottom=1 start=subnavgroup_library dir=down }
 
@@ -570,7 +570,7 @@ layout [$OSX||$LINUX] //Both OSX and Linux use OS provided menu bar, so this mov
 	place { control=ScreenshotsPage 	y=39 width=max height=max margin-top=1 start=subnavgroup_library dir=down }
 
 	place { control=ConsolePage 		y=39 width=max height=max margin-bottom=1 start=subnavgroup_library dir=down }
-  place { control=NewLibraryPage	width=max height=max margin-top=40 margin-left=-6 margin-right=0 margin-bottom=1 start=subnavgroup_library dir=down }
+  place { control=NewLibraryPage	width=max height=max margin-top=40 margin-left=0 margin-right=0 margin-bottom=1 start=subnavgroup_library dir=down }
 	place { control=MediaPage 			y=39 width=max height=max margin-bottom=1 start=subnavgroup_library dir=down }
 	place { control=ToolsPage 			y=39 width=max height=max margin-bottom=1 start=subnavgroup_library dir=down }
 


### PR DESCRIPTION
Changed margin-left to 0 from -6 for control=NewLibraryPage under layout otherwise everything in the left sidebar hugs the left side of the window. Tested for Windows, seems to be working fine. Can't say for Linux/OSX.

_(Ques - Why was margin-left -6 though?)_